### PR TITLE
package.json fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "author": "Preethi Kasireddy",
   "license": "ISC",
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.11.4",
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.11.4",
     "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
> deprecated babel@6.23.0: In 6.x, the babel package has been deprecated in favor of babel-cli.

When you execute `build:langs `

> You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
> Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package. 